### PR TITLE
Fix errors in Eagle template

### DIFF
--- a/template/eaglecad/mezza.brd
+++ b/template/eaglecad/mezza.brd
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.6.0">
+<eagle version="9.5.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="no"/>
+<setting alwaysvectorfont="yes"/>
+<setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
 <grid distance="0.1" unitdist="mm" unit="mm" style="lines" multiple="5" display="no" altdistance="0.025" altunitdist="inch" altunit="mm"/>
@@ -170,96 +171,56 @@
 <description>Generated from &lt;b&gt;mezza.sch&lt;/b&gt;&lt;p&gt;
 by exp-lbrs.ulp</description>
 <packages>
-<package name="55510-140LF">
-<wire x1="-20" y1="2" x2="-20" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="20" y2="-2" width="0.127" layer="20"/>
-<wire x1="-20" y1="2" x2="-19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-20" y1="-2" x2="-19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="20" y1="-2" x2="19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="2" x2="-17.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="-2" x2="-17.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="2" x2="-15.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="2" x2="-13.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="2" x2="-11.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="-2" x2="-15.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="-2" x2="-13.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="2" x2="-9.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="2" x2="-7.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="2" x2="-5.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="2" x2="-3.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="2" x2="-1.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="2" x2="0.4" y2="2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="2" x2="2.4" y2="2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="2" x2="4.4" y2="2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="2" x2="6.4" y2="2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="2" x2="8.4" y2="2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="2" x2="10.4" y2="2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="2" x2="12.4" y2="2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="2" x2="14.4" y2="2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="2" x2="16.4" y2="2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="2" x2="18.4" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="-2" x2="-11.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="-2" x2="-9.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="-2" x2="-7.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="-2" x2="-5.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="-2" x2="-3.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="-2" x2="-1.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="-2" x2="0.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="-2" x2="2.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="-2" x2="4.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="-2" x2="6.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="-2" x2="8.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="-2" x2="10.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="-2" x2="12.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="-2" x2="14.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="-2" x2="16.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="-2" x2="18.4" y2="-2" width="0.127" layer="20"/>
-<smd name="P$1" x="-19" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$2" x="-19" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$3" x="-17" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$4" x="-17" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$5" x="-15" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$6" x="-15" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$7" x="-13" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$8" x="-13" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$9" x="-11" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$10" x="-11" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$11" x="-9" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$12" x="-9" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$13" x="-7" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$14" x="-7" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$15" x="-5" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$16" x="-5" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$17" x="-3" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$18" x="-3" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$19" x="-1" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$20" x="-1" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$21" x="1" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$22" x="1" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$23" x="3" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$24" x="3" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$25" x="5" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$26" x="5" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$27" x="7" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$28" x="7" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$29" x="9" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$30" x="9" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$31" x="11" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$32" x="11" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$33" x="13" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$34" x="13" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$35" x="15" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$36" x="15" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$37" x="17" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$38" x="17" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$39" x="19" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$40" x="19" y="-2.5" dx="1" dy="1.5" layer="1"/>
+<package name="57202-G52-20LF">
+<smd name="P$1" x="-19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$2" x="-19" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$3" x="-17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$4" x="-17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$5" x="-15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$6" x="-15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$7" x="-13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$8" x="-13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$9" x="-11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$10" x="-11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$11" x="-9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$12" x="-9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$13" x="-7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$14" x="-7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$15" x="-5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$16" x="-5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$17" x="-3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$18" x="-3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$19" x="-1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$20" x="-1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$21" x="1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$22" x="1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$23" x="3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$24" x="3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$25" x="5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$26" x="5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$27" x="7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$28" x="7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$29" x="9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$30" x="9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$31" x="11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$32" x="11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$33" x="13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$34" x="13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$35" x="15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$36" x="15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$37" x="17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$38" x="17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$39" x="19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$40" x="19" y="-2" dx="1" dy="2.5" layer="1"/>
 <text x="-21.5" y="2" size="1.27" layer="21">1</text>
 <text x="-21.5" y="-3" size="1.27" layer="21">2</text>
 <text x="20.5" y="-3" size="1.27" layer="21">40</text>
 <text x="20.5" y="2" size="1.27" layer="21">39</text>
 <text x="24.13" y="-3.81" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<wire x1="-19.939" y1="2.032" x2="-19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-19.939" y1="-2.032" x2="19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="-2.032" x2="19.939" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="2.032" x2="-19.939" y2="2.032" width="0.1524" layer="21"/>
 </package>
 <package name="61083-063402LF">
 <wire x1="-12" y1="3" x2="-15" y2="3" width="0.127" layer="21"/>
@@ -450,16 +411,23 @@ design rules under a new name.</description>
 <param name="slThermalsForVias" value="0"/>
 <param name="dpMaxLengthDifference" value="10mm"/>
 <param name="dpGapFactor" value="2.5"/>
-<param name="checkGrid" value="0"/>
 <param name="checkAngle" value="0"/>
 <param name="checkFont" value="1"/>
 <param name="checkRestrict" value="1"/>
+<param name="checkStop" value="0"/>
+<param name="checkValues" value="0"/>
+<param name="checkNames" value="1"/>
+<param name="checkWireStubs" value="1"/>
+<param name="checkPolygonWidth" value="0"/>
 <param name="useDiameter" value="13"/>
 <param name="maxErrors" value="50"/>
 </designrules>
 <autorouter>
 <pass name="Default">
 <param name="RoutingGrid" value="50mil"/>
+<param name="AutoGrid" value="1"/>
+<param name="Efforts" value="0"/>
+<param name="TopRouterVariant" value="1"/>
 <param name="tpViaShape" value="round"/>
 <param name="PrefDir.1" value="|"/>
 <param name="PrefDir.2" value="0"/>
@@ -551,8 +519,8 @@ design rules under a new name.</description>
 </pass>
 </autorouter>
 <elements>
-<element name="PCB1" library="mezza" package="DRAGONBOARD410C" value="DB410C-PCB-FOOTPRINT" x="0" y="0"/>
-<element name="J1" library="mezza" package="55510-140LF" value="55510-140LF" x="29" y="50" smashed="yes" rot="MR180">
+<element name="PCB1" library="mezza" package="DRAGONBOARD410C" value="DB410C-PCB-FOOTPRINT" x="0" y="0" smashed="yes"/>
+<element name="J1" library="mezza" package="57202-G52-20LF" value="57202-G52-20LF" x="29" y="50" smashed="yes" rot="MR180">
 <attribute name="NAME" x="8.68" y="51" size="1.27" layer="26" rot="MR270"/>
 </element>
 <element name="J2" library="mezza" package="61083-063402LF" value="61083-063402LF" x="32.75" y="15.45" smashed="yes" rot="MR180">
@@ -587,9 +555,9 @@ design rules under a new name.</description>
 <contactref element="J2" pad="P$52"/>
 <contactref element="J2" pad="P$58"/>
 <wire x1="81" y1="18.5" x2="81" y2="50" width="0" layer="19" extent="1-1"/>
-<wire x1="48" y1="52.5" x2="81" y2="50" width="0" layer="19" extent="16-16"/>
-<wire x1="48" y1="47.5" x2="48" y2="52.5" width="0" layer="19" extent="16-16"/>
-<wire x1="43.55" y1="17.65" x2="48" y2="47.5" width="0" layer="19" extent="16-16"/>
+<wire x1="48" y1="52" x2="81" y2="50" width="0" layer="19" extent="16-16"/>
+<wire x1="48" y1="48" x2="48" y2="52" width="0" layer="19" extent="16-16"/>
+<wire x1="43.55" y1="17.65" x2="48" y2="48" width="0" layer="19" extent="16-16"/>
 <wire x1="41.15" y1="17.65" x2="43.55" y2="17.65" width="0" layer="19" extent="16-16"/>
 <wire x1="38.75" y1="17.65" x2="41.15" y2="17.65" width="0" layer="19" extent="16-16"/>
 <wire x1="36.35" y1="17.65" x2="38.75" y2="17.65" width="0" layer="19" extent="16-16"/>
@@ -607,9 +575,9 @@ design rules under a new name.</description>
 <wire x1="28.35" y1="13.25" x2="30.75" y2="13.25" width="0" layer="19" extent="16-16"/>
 <wire x1="25.95" y1="13.25" x2="28.35" y2="13.25" width="0" layer="19" extent="16-16"/>
 <wire x1="4" y1="18.5" x2="22.75" y2="17.65" width="0" layer="19" extent="16-16"/>
-<wire x1="10" y1="47.5" x2="4" y2="18.5" width="0" layer="19" extent="16-16"/>
-<wire x1="10" y1="52.5" x2="10" y2="47.5" width="0" layer="19" extent="16-16"/>
-<wire x1="4" y1="50" x2="10" y2="47.5" width="0" layer="19" extent="16-16"/>
+<wire x1="10" y1="48" x2="4" y2="18.5" width="0" layer="19" extent="16-16"/>
+<wire x1="10" y1="52" x2="10" y2="48" width="0" layer="19" extent="16-16"/>
+<wire x1="4" y1="50" x2="10" y2="48" width="0" layer="19" extent="16-16"/>
 </signal>
 <signal name="UART0_CTS">
 <contactref element="J1" pad="P$3"/>
@@ -824,7 +792,7 @@ design rules under a new name.</description>
 <signal name="SYS_DCIN">
 <contactref element="J1" pad="P$36"/>
 <contactref element="J1" pad="P$38"/>
-<wire x1="44" y1="52.5" x2="46" y2="52.5" width="0" layer="19" extent="16-16"/>
+<wire x1="44" y1="52" x2="46" y2="52" width="0" layer="19" extent="16-16"/>
 </signal>
 <signal name="SD_DAT1">
 <contactref element="J2" pad="P$3"/>
@@ -848,6 +816,13 @@ design rules under a new name.</description>
 <contactref element="J1" pad="P$22"/>
 </signal>
 </signals>
+<mfgpreviewcolors>
+<mfgpreviewcolor name="soldermaskcolor" color="0xC8008000"/>
+<mfgpreviewcolor name="silkscreencolor" color="0xFFFEFEFE"/>
+<mfgpreviewcolor name="backgroundcolor" color="0xFF282828"/>
+<mfgpreviewcolor name="coppercolor" color="0xFFFFBF00"/>
+<mfgpreviewcolor name="substratecolor" color="0xFF786E46"/>
+</mfgpreviewcolors>
 </board>
 </drawing>
 </eagle>

--- a/template/eaglecad/mezza.lbr
+++ b/template/eaglecad/mezza.lbr
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.6.0">
+<eagle version="9.5.2">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
+<setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
-<grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
+<grid distance="50" unitdist="mil" unit="mm" style="lines" multiple="1" display="yes" altdistance="5" altunitdist="mil" altunit="mil"/>
 <layers>
 <layer number="1" name="Top" color="4" fill="1" visible="yes" active="yes"/>
-<layer number="2" name="Route2" color="1" fill="3" visible="no" active="yes"/>
-<layer number="3" name="Route3" color="4" fill="3" visible="no" active="yes"/>
-<layer number="4" name="Route4" color="1" fill="4" visible="no" active="yes"/>
-<layer number="5" name="Route5" color="4" fill="4" visible="no" active="yes"/>
-<layer number="6" name="Route6" color="1" fill="8" visible="no" active="yes"/>
-<layer number="7" name="Route7" color="4" fill="8" visible="no" active="yes"/>
-<layer number="8" name="Route8" color="1" fill="2" visible="no" active="yes"/>
-<layer number="9" name="Route9" color="4" fill="2" visible="no" active="yes"/>
-<layer number="10" name="Route10" color="1" fill="7" visible="no" active="yes"/>
-<layer number="11" name="Route11" color="4" fill="7" visible="no" active="yes"/>
-<layer number="12" name="Route12" color="1" fill="5" visible="no" active="yes"/>
-<layer number="13" name="Route13" color="4" fill="5" visible="no" active="yes"/>
-<layer number="14" name="Route14" color="1" fill="6" visible="no" active="yes"/>
-<layer number="15" name="Route15" color="4" fill="6" visible="no" active="yes"/>
+<layer number="2" name="Route2" color="1" fill="3" visible="yes" active="yes"/>
+<layer number="3" name="Route3" color="4" fill="3" visible="yes" active="yes"/>
+<layer number="4" name="Route4" color="1" fill="4" visible="yes" active="yes"/>
+<layer number="5" name="Route5" color="4" fill="4" visible="yes" active="yes"/>
+<layer number="6" name="Route6" color="1" fill="8" visible="yes" active="yes"/>
+<layer number="7" name="Route7" color="4" fill="8" visible="yes" active="yes"/>
+<layer number="8" name="Route8" color="1" fill="2" visible="yes" active="yes"/>
+<layer number="9" name="Route9" color="4" fill="2" visible="yes" active="yes"/>
+<layer number="10" name="Route10" color="1" fill="7" visible="yes" active="yes"/>
+<layer number="11" name="Route11" color="4" fill="7" visible="yes" active="yes"/>
+<layer number="12" name="Route12" color="1" fill="5" visible="yes" active="yes"/>
+<layer number="13" name="Route13" color="4" fill="5" visible="yes" active="yes"/>
+<layer number="14" name="Route14" color="1" fill="6" visible="yes" active="yes"/>
+<layer number="15" name="Route15" color="4" fill="6" visible="yes" active="yes"/>
 <layer number="16" name="Bottom" color="1" fill="1" visible="yes" active="yes"/>
 <layer number="17" name="Pads" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="18" name="Vias" color="2" fill="1" visible="yes" active="yes"/>
@@ -34,8 +35,8 @@
 <layer number="24" name="bOrigins" color="15" fill="1" visible="yes" active="yes"/>
 <layer number="25" name="tNames" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="26" name="bNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="27" name="tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="28" name="bValues" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="27" name="tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="28" name="bValues" color="7" fill="1" visible="no" active="yes"/>
 <layer number="29" name="tStop" color="7" fill="3" visible="no" active="yes"/>
 <layer number="30" name="bStop" color="7" fill="6" visible="no" active="yes"/>
 <layer number="31" name="tCream" color="7" fill="4" visible="no" active="yes"/>
@@ -50,24 +51,24 @@
 <layer number="40" name="bKeepout" color="1" fill="11" visible="yes" active="yes"/>
 <layer number="41" name="tRestrict" color="4" fill="10" visible="yes" active="yes"/>
 <layer number="42" name="bRestrict" color="1" fill="10" visible="yes" active="yes"/>
-<layer number="43" name="vRestrict" color="2" fill="10" visible="yes" active="yes"/>
+<layer number="43" name="vRestrict" color="2" fill="10" visible="no" active="yes"/>
 <layer number="44" name="Drills" color="7" fill="1" visible="no" active="yes"/>
 <layer number="45" name="Holes" color="7" fill="1" visible="no" active="yes"/>
 <layer number="46" name="Milling" color="3" fill="1" visible="no" active="yes"/>
 <layer number="47" name="Measures" color="7" fill="1" visible="no" active="yes"/>
 <layer number="48" name="Document" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="49" name="Reference" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="50" name="dxf" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="50" name="dxf" color="7" fill="1" visible="no" active="yes"/>
 <layer number="51" name="tDocu" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="52" name="bDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="56" name="wert" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="57" name="tCAD" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="59" name="tCarbon" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="60" name="bCarbon" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="61" name="stand" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="70" name="70" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="53" name="tGND_GNDA" color="7" fill="1" visible="no" active="yes"/>
+<layer number="54" name="bGND_GNDA" color="7" fill="1" visible="no" active="yes"/>
+<layer number="56" name="wert" color="7" fill="1" visible="no" active="yes"/>
+<layer number="57" name="tCAD" color="7" fill="1" visible="no" active="yes"/>
+<layer number="59" name="tCarbon" color="7" fill="1" visible="no" active="yes"/>
+<layer number="60" name="bCarbon" color="7" fill="1" visible="no" active="yes"/>
+<layer number="61" name="stand" color="7" fill="1" visible="no" active="yes"/>
+<layer number="70" name="70" color="7" fill="1" visible="no" active="yes"/>
 <layer number="90" name="Modules" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="91" name="Nets" color="2" fill="1" visible="yes" active="yes"/>
 <layer number="92" name="Busses" color="1" fill="1" visible="yes" active="yes"/>
@@ -78,134 +79,90 @@
 <layer number="97" name="Info" color="7" fill="1" visible="yes" active="yes"/>
 <layer number="98" name="Guide" color="6" fill="1" visible="yes" active="yes"/>
 <layer number="99" name="SpiceOrder" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="100" name="ANNOTATIONS" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="101" name="Patch_Top" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="102" name="Vscore" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="103" name="fp3" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="104" name="Name" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="105" name="Beschreib" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="106" name="BGA-Top" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="107" name="BD-Top" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="108" name="fp8" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="109" name="fp9" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="110" name="fp0" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="111" name="LPC17xx" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="112" name="tSilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="113" name="IDFDebug" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="116" name="Patch_BOT" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="118" name="Rect_Pads" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="121" name="_tsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="122" name="_bsilk" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="123" name="tTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="124" name="bTestmark" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="125" name="_tNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="126" name="_bNames" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="127" name="_tValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="128" name="_bValues" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="129" name="Mask" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="130" name="bLogo" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="131" name="tAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="132" name="bAdjust" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="144" name="Drill_legend" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="150" name="Notes" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="151" name="HeatSink" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="152" name="_bDocu" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="153" name="FabDoc1" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="154" name="FabDoc2" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="155" name="FabDoc3" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="160" name="GErr" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="161" name="GErrText" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="199" name="Contour" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="200" name="200bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="201" name="201bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="202" name="202bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="203" name="203bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="204" name="204bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="205" name="205bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="206" name="206bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="207" name="207bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="208" name="208bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="209" name="209bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="210" name="210bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="211" name="211bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="212" name="212bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="213" name="213bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="214" name="214bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="215" name="215bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="216" name="216bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="217" name="217bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="218" name="218bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="219" name="219bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="220" name="220bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="221" name="221bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="222" name="A10_SCH_PDF" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="223" name="223bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="224" name="224bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="225" name="225bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="226" name="226bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="227" name="227bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="228" name="228bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="229" name="229bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="230" name="230bmp" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="248" name="Housing" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="249" name="Edge" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="250" name="Descript" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="251" name="SMDround" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="254" name="cooling" color="7" fill="1" visible="yes" active="yes"/>
-<layer number="255" name="routoute" color="7" fill="1" visible="yes" active="yes"/>
+<layer number="100" name="ANNOTATIONS" color="7" fill="1" visible="no" active="yes"/>
+<layer number="101" name="Patch_Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="102" name="Vscore" color="7" fill="1" visible="no" active="yes"/>
+<layer number="103" name="fp3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="104" name="Name" color="7" fill="1" visible="no" active="yes"/>
+<layer number="105" name="Beschreib" color="7" fill="1" visible="no" active="yes"/>
+<layer number="106" name="BGA-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="107" name="BD-Top" color="7" fill="1" visible="no" active="yes"/>
+<layer number="108" name="fp8" color="7" fill="1" visible="no" active="yes"/>
+<layer number="109" name="fp9" color="7" fill="1" visible="no" active="yes"/>
+<layer number="110" name="fp0" color="7" fill="1" visible="no" active="yes"/>
+<layer number="111" name="LPC17xx" color="7" fill="1" visible="no" active="yes"/>
+<layer number="112" name="tSilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="113" name="IDFDebug" color="7" fill="1" visible="no" active="yes"/>
+<layer number="116" name="Patch_BOT" color="7" fill="1" visible="no" active="yes"/>
+<layer number="118" name="Rect_Pads" color="7" fill="1" visible="no" active="yes"/>
+<layer number="121" name="_tsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="122" name="_bsilk" color="7" fill="1" visible="no" active="yes"/>
+<layer number="123" name="tTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="124" name="bTestmark" color="7" fill="1" visible="no" active="yes"/>
+<layer number="125" name="_tNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="126" name="_bNames" color="7" fill="1" visible="no" active="yes"/>
+<layer number="127" name="_tValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="128" name="_bValues" color="7" fill="1" visible="no" active="yes"/>
+<layer number="129" name="Mask" color="7" fill="1" visible="no" active="yes"/>
+<layer number="130" name="bLogo" color="7" fill="1" visible="no" active="yes"/>
+<layer number="131" name="tAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="132" name="bAdjust" color="7" fill="1" visible="no" active="yes"/>
+<layer number="144" name="Drill_legend" color="7" fill="1" visible="no" active="yes"/>
+<layer number="150" name="Notes" color="7" fill="1" visible="no" active="yes"/>
+<layer number="151" name="HeatSink" color="7" fill="1" visible="no" active="yes"/>
+<layer number="152" name="_bDocu" color="7" fill="1" visible="no" active="yes"/>
+<layer number="153" name="FabDoc1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="154" name="FabDoc2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="155" name="FabDoc3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="160" name="GErr" color="7" fill="1" visible="no" active="yes"/>
+<layer number="161" name="GErrText" color="7" fill="1" visible="no" active="yes"/>
+<layer number="199" name="Contour" color="7" fill="1" visible="no" active="yes"/>
+<layer number="200" name="200bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="201" name="201bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="202" name="202bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="203" name="203bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="204" name="204bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="205" name="205bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="206" name="206bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="207" name="207bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="208" name="208bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="209" name="209bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="210" name="210bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="211" name="211bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="212" name="212bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="213" name="213bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="214" name="214bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="215" name="215bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="216" name="216bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="217" name="217bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="218" name="218bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="219" name="219bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="220" name="220bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="221" name="221bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="222" name="A10_SCH_PDF" color="7" fill="1" visible="no" active="yes"/>
+<layer number="223" name="223bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="224" name="224bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="225" name="225bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="226" name="226bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="227" name="227bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="228" name="228bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="229" name="229bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="230" name="230bmp" color="7" fill="1" visible="no" active="yes"/>
+<layer number="231" name="Eagle3D_PG1" color="7" fill="1" visible="no" active="yes"/>
+<layer number="232" name="Eagle3D_PG2" color="7" fill="1" visible="no" active="yes"/>
+<layer number="233" name="Eagle3D_PG3" color="7" fill="1" visible="no" active="yes"/>
+<layer number="248" name="Housing" color="7" fill="1" visible="no" active="yes"/>
+<layer number="249" name="Edge" color="7" fill="1" visible="no" active="yes"/>
+<layer number="250" name="Descript" color="7" fill="1" visible="no" active="yes"/>
+<layer number="251" name="SMDround" color="7" fill="1" visible="no" active="yes"/>
+<layer number="254" name="cooling" color="7" fill="1" visible="no" active="yes"/>
+<layer number="255" name="routoute" color="7" fill="1" visible="no" active="yes"/>
 </layers>
 <library>
 <description>Generated from &lt;b&gt;mezza.sch&lt;/b&gt;&lt;p&gt;
 by exp-lbrs.ulp</description>
 <packages>
 <package name="55510-140LF">
-<wire x1="-20" y1="2" x2="-20" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="20" y2="-2" width="0.127" layer="20"/>
-<wire x1="-20" y1="2" x2="-19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-20" y1="-2" x2="-19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="20" y1="-2" x2="19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="2" x2="-17.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="-2" x2="-17.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="2" x2="-15.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="2" x2="-13.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="2" x2="-11.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="-2" x2="-15.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="-2" x2="-13.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="2" x2="-9.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="2" x2="-7.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="2" x2="-5.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="2" x2="-3.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="2" x2="-1.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="2" x2="0.4" y2="2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="2" x2="2.4" y2="2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="2" x2="4.4" y2="2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="2" x2="6.4" y2="2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="2" x2="8.4" y2="2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="2" x2="10.4" y2="2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="2" x2="12.4" y2="2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="2" x2="14.4" y2="2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="2" x2="16.4" y2="2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="2" x2="18.4" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="-2" x2="-11.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="-2" x2="-9.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="-2" x2="-7.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="-2" x2="-5.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="-2" x2="-3.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="-2" x2="-1.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="-2" x2="0.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="-2" x2="2.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="-2" x2="4.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="-2" x2="6.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="-2" x2="8.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="-2" x2="10.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="-2" x2="12.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="-2" x2="14.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="-2" x2="16.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="-2" x2="18.4" y2="-2" width="0.127" layer="20"/>
 <smd name="P$1" x="-19" y="2.5" dx="1" dy="1.5" layer="1"/>
 <smd name="P$2" x="-19" y="-2.5" dx="1" dy="1.5" layer="1"/>
 <smd name="P$3" x="-17" y="2.5" dx="1" dy="1.5" layer="1"/>
@@ -251,6 +208,10 @@ by exp-lbrs.ulp</description>
 <text x="20.5" y="-3" size="1.27" layer="21">40</text>
 <text x="20.5" y="2" size="1.27" layer="21">39</text>
 <text x="24.13" y="-3.81" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<wire x1="-19.939" y1="2.032" x2="-19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-19.939" y1="-2.032" x2="19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="-2.032" x2="19.939" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="2.032" x2="-19.939" y2="2.032" width="0.1524" layer="21"/>
 </package>
 <package name="61083-063402LF">
 <wire x1="-12" y1="3" x2="-15" y2="3" width="0.127" layer="21"/>
@@ -444,6 +405,57 @@ by exp-lbrs.ulp</description>
 <text x="29.5" y="50.5" size="0.4064" layer="100">y=50.0</text>
 <text x="29.5" y="49" size="0.4064" layer="100">LS Connector</text>
 <text x="33.5" y="14.5" size="0.4064" layer="100">HS Connector</text>
+</package>
+<package name="57202-G52-20LF">
+<smd name="P$1" x="-19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$2" x="-19" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$3" x="-17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$4" x="-17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$5" x="-15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$6" x="-15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$7" x="-13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$8" x="-13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$9" x="-11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$10" x="-11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$11" x="-9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$12" x="-9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$13" x="-7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$14" x="-7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$15" x="-5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$16" x="-5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$17" x="-3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$18" x="-3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$19" x="-1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$20" x="-1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$21" x="1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$22" x="1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$23" x="3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$24" x="3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$25" x="5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$26" x="5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$27" x="7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$28" x="7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$29" x="9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$30" x="9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$31" x="11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$32" x="11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$33" x="13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$34" x="13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$35" x="15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$36" x="15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$37" x="17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$38" x="17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$39" x="19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$40" x="19" y="-2" dx="1" dy="2.5" layer="1"/>
+<text x="-21.5" y="2" size="1.27" layer="21">1</text>
+<text x="-21.5" y="-3" size="1.27" layer="21">2</text>
+<text x="20.5" y="-3" size="1.27" layer="21">40</text>
+<text x="20.5" y="2" size="1.27" layer="21">39</text>
+<text x="24.13" y="-3.81" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<wire x1="-19.939" y1="2.032" x2="-19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-19.939" y1="-2.032" x2="19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="-2.032" x2="19.939" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="2.032" x2="-19.939" y2="2.032" width="0.1524" layer="21"/>
 </package>
 </packages>
 <symbols>
@@ -773,6 +785,54 @@ by exp-lbrs.ulp</description>
 <pin name="GND" x="0" y="2.54" visible="off" length="short" direction="sup" rot="R270"/>
 <text x="-1.905" y="-3.175" size="1.778" layer="96">&gt;VALUE</text>
 </symbol>
+<symbol name="40PIN-HEADER_MALE">
+<wire x1="-7.62" y1="27.94" x2="7.62" y2="27.94" width="0.254" layer="94"/>
+<wire x1="7.62" y1="27.94" x2="7.62" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="7.62" y1="-25.4" x2="-7.62" y2="-25.4" width="0.254" layer="94"/>
+<wire x1="-7.62" y1="-25.4" x2="-7.62" y2="27.94" width="0.254" layer="94"/>
+<pin name="P$1" x="-10.16" y="25.4" length="short"/>
+<pin name="P$2" x="10.16" y="25.4" length="short" rot="R180"/>
+<pin name="P$3" x="-10.16" y="22.86" length="short"/>
+<pin name="P$4" x="10.16" y="22.86" length="short" rot="R180"/>
+<pin name="P$5" x="-10.16" y="20.32" length="short"/>
+<pin name="P$6" x="10.16" y="20.32" length="short" rot="R180"/>
+<pin name="P$7" x="-10.16" y="17.78" length="short"/>
+<pin name="P$8" x="10.16" y="17.78" length="short" rot="R180"/>
+<pin name="P$9" x="-10.16" y="15.24" length="short"/>
+<pin name="P$10" x="10.16" y="15.24" length="short" rot="R180"/>
+<pin name="P$11" x="-10.16" y="12.7" length="short"/>
+<pin name="P$12" x="10.16" y="12.7" length="short" rot="R180"/>
+<pin name="P$13" x="-10.16" y="10.16" length="short"/>
+<pin name="P$14" x="10.16" y="10.16" length="short" rot="R180"/>
+<pin name="P$15" x="-10.16" y="7.62" length="short"/>
+<pin name="P$16" x="10.16" y="7.62" length="short" rot="R180"/>
+<pin name="P$17" x="-10.16" y="5.08" length="short"/>
+<pin name="P$18" x="10.16" y="5.08" length="short" rot="R180"/>
+<pin name="P$19" x="-10.16" y="2.54" length="short"/>
+<pin name="P$20" x="10.16" y="2.54" length="short" rot="R180"/>
+<pin name="P$21" x="-10.16" y="0" length="short"/>
+<pin name="P$22" x="10.16" y="0" length="short" rot="R180"/>
+<pin name="P$23" x="-10.16" y="-2.54" length="short"/>
+<pin name="P$24" x="10.16" y="-2.54" length="short" rot="R180"/>
+<pin name="P$25" x="-10.16" y="-5.08" length="short"/>
+<pin name="P$26" x="10.16" y="-5.08" length="short" rot="R180"/>
+<pin name="P$27" x="-10.16" y="-7.62" length="short"/>
+<pin name="P$28" x="10.16" y="-7.62" length="short" rot="R180"/>
+<pin name="P$29" x="-10.16" y="-10.16" length="short"/>
+<pin name="P$30" x="10.16" y="-10.16" length="short" rot="R180"/>
+<pin name="P$31" x="-10.16" y="-12.7" length="short"/>
+<pin name="P$32" x="10.16" y="-12.7" length="short" rot="R180"/>
+<pin name="P$33" x="-10.16" y="-15.24" length="short"/>
+<pin name="P$34" x="10.16" y="-15.24" length="short" rot="R180"/>
+<pin name="P$35" x="-10.16" y="-17.78" length="short"/>
+<pin name="P$36" x="10.16" y="-17.78" length="short" rot="R180"/>
+<pin name="P$37" x="-10.16" y="-20.32" length="short"/>
+<pin name="P$38" x="10.16" y="-20.32" length="short" rot="R180"/>
+<pin name="P$39" x="-10.16" y="-22.86" length="short"/>
+<pin name="P$40" x="10.16" y="-22.86" length="short" rot="R180"/>
+<text x="-7.62" y="-27.94" size="1.27" layer="95">&gt;NAME</text>
+<text x="-7.62" y="-30.48" size="1.27" layer="96">&gt;VALUE</text>
+</symbol>
 </symbols>
 <devicesets>
 <deviceset name="A4L-LOC" prefix="FRAME" uservalue="yes">
@@ -1017,6 +1077,60 @@ DIN A4, landscape with location and doc. field</description>
 </gates>
 <devices>
 <device name="">
+<technologies>
+<technology name=""/>
+</technologies>
+</device>
+</devices>
+</deviceset>
+<deviceset name="57202-G52-20LF">
+<gates>
+<gate name="G$1" symbol="40PIN-HEADER_MALE" x="0" y="0"/>
+</gates>
+<devices>
+<device name="" package="57202-G52-20LF">
+<connects>
+<connect gate="G$1" pin="P$1" pad="P$1"/>
+<connect gate="G$1" pin="P$10" pad="P$10"/>
+<connect gate="G$1" pin="P$11" pad="P$11"/>
+<connect gate="G$1" pin="P$12" pad="P$12"/>
+<connect gate="G$1" pin="P$13" pad="P$13"/>
+<connect gate="G$1" pin="P$14" pad="P$14"/>
+<connect gate="G$1" pin="P$15" pad="P$15"/>
+<connect gate="G$1" pin="P$16" pad="P$16"/>
+<connect gate="G$1" pin="P$17" pad="P$17"/>
+<connect gate="G$1" pin="P$18" pad="P$18"/>
+<connect gate="G$1" pin="P$19" pad="P$19"/>
+<connect gate="G$1" pin="P$2" pad="P$2"/>
+<connect gate="G$1" pin="P$20" pad="P$20"/>
+<connect gate="G$1" pin="P$21" pad="P$21"/>
+<connect gate="G$1" pin="P$22" pad="P$22"/>
+<connect gate="G$1" pin="P$23" pad="P$23"/>
+<connect gate="G$1" pin="P$24" pad="P$24"/>
+<connect gate="G$1" pin="P$25" pad="P$25"/>
+<connect gate="G$1" pin="P$26" pad="P$26"/>
+<connect gate="G$1" pin="P$27" pad="P$27"/>
+<connect gate="G$1" pin="P$28" pad="P$28"/>
+<connect gate="G$1" pin="P$29" pad="P$29"/>
+<connect gate="G$1" pin="P$3" pad="P$3"/>
+<connect gate="G$1" pin="P$30" pad="P$30"/>
+<connect gate="G$1" pin="P$31" pad="P$31"/>
+<connect gate="G$1" pin="P$32" pad="P$32"/>
+<connect gate="G$1" pin="P$33" pad="P$33"/>
+<connect gate="G$1" pin="P$34" pad="P$34"/>
+<connect gate="G$1" pin="P$35" pad="P$35"/>
+<connect gate="G$1" pin="P$36" pad="P$36"/>
+<connect gate="G$1" pin="P$37" pad="P$37"/>
+<connect gate="G$1" pin="P$38" pad="P$38"/>
+<connect gate="G$1" pin="P$39" pad="P$39"/>
+<connect gate="G$1" pin="P$4" pad="P$4"/>
+<connect gate="G$1" pin="P$40" pad="P$40"/>
+<connect gate="G$1" pin="P$5" pad="P$5"/>
+<connect gate="G$1" pin="P$6" pad="P$6"/>
+<connect gate="G$1" pin="P$7" pad="P$7"/>
+<connect gate="G$1" pin="P$8" pad="P$8"/>
+<connect gate="G$1" pin="P$9" pad="P$9"/>
+</connects>
 <technologies>
 <technology name=""/>
 </technologies>

--- a/template/eaglecad/mezza.sch
+++ b/template/eaglecad/mezza.sch
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="6.6.0">
+<eagle version="9.5.2">
 <drawing>
 <settings>
-<setting alwaysvectorfont="no"/>
+<setting alwaysvectorfont="yes"/>
+<setting keepoldvectorfont="yes"/>
 <setting verticaltext="up"/>
 </settings>
 <grid distance="0.1" unitdist="inch" unit="inch" style="lines" multiple="1" display="no" altdistance="0.01" altunitdist="inch" altunit="inch"/>
@@ -243,96 +244,56 @@ DIN A4, landscape with location and doc. field</description>
 <description>Generated from &lt;b&gt;mezza.sch&lt;/b&gt;&lt;p&gt;
 by exp-lbrs.ulp</description>
 <packages>
-<package name="55510-140LF">
-<wire x1="-20" y1="2" x2="-20" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="20" y2="-2" width="0.127" layer="20"/>
-<wire x1="-20" y1="2" x2="-19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-20" y1="-2" x2="-19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="20" y1="2" x2="19.6" y2="2" width="0.127" layer="20"/>
-<wire x1="20" y1="-2" x2="19.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="2" x2="-17.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-18.4" y1="-2" x2="-17.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="2" x2="-15.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="2" x2="-13.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="2" x2="-11.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-16.4" y1="-2" x2="-15.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-14.4" y1="-2" x2="-13.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="2" x2="-9.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="2" x2="-7.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="2" x2="-5.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="2" x2="-3.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="2" x2="-1.6" y2="2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="2" x2="0.4" y2="2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="2" x2="2.4" y2="2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="2" x2="4.4" y2="2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="2" x2="6.4" y2="2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="2" x2="8.4" y2="2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="2" x2="10.4" y2="2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="2" x2="12.4" y2="2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="2" x2="14.4" y2="2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="2" x2="16.4" y2="2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="2" x2="18.4" y2="2" width="0.127" layer="20"/>
-<wire x1="-12.4" y1="-2" x2="-11.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-10.4" y1="-2" x2="-9.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-8.4" y1="-2" x2="-7.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-6.4" y1="-2" x2="-5.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-4.4" y1="-2" x2="-3.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-2.4" y1="-2" x2="-1.6" y2="-2" width="0.127" layer="20"/>
-<wire x1="-0.4" y1="-2" x2="0.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="1.6" y1="-2" x2="2.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="3.6" y1="-2" x2="4.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="5.6" y1="-2" x2="6.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="7.6" y1="-2" x2="8.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="9.6" y1="-2" x2="10.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="11.6" y1="-2" x2="12.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="13.6" y1="-2" x2="14.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="15.6" y1="-2" x2="16.4" y2="-2" width="0.127" layer="20"/>
-<wire x1="17.6" y1="-2" x2="18.4" y2="-2" width="0.127" layer="20"/>
-<smd name="P$1" x="-19" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$2" x="-19" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$3" x="-17" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$4" x="-17" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$5" x="-15" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$6" x="-15" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$7" x="-13" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$8" x="-13" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$9" x="-11" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$10" x="-11" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$11" x="-9" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$12" x="-9" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$13" x="-7" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$14" x="-7" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$15" x="-5" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$16" x="-5" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$17" x="-3" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$18" x="-3" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$19" x="-1" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$20" x="-1" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$21" x="1" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$22" x="1" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$23" x="3" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$24" x="3" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$25" x="5" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$26" x="5" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$27" x="7" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$28" x="7" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$29" x="9" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$30" x="9" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$31" x="11" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$32" x="11" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$33" x="13" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$34" x="13" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$35" x="15" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$36" x="15" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$37" x="17" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$38" x="17" y="-2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$39" x="19" y="2.5" dx="1" dy="1.5" layer="1"/>
-<smd name="P$40" x="19" y="-2.5" dx="1" dy="1.5" layer="1"/>
+<package name="57202-G52-20LF">
+<smd name="P$1" x="-19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$2" x="-19" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$3" x="-17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$4" x="-17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$5" x="-15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$6" x="-15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$7" x="-13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$8" x="-13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$9" x="-11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$10" x="-11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$11" x="-9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$12" x="-9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$13" x="-7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$14" x="-7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$15" x="-5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$16" x="-5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$17" x="-3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$18" x="-3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$19" x="-1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$20" x="-1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$21" x="1" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$22" x="1" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$23" x="3" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$24" x="3" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$25" x="5" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$26" x="5" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$27" x="7" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$28" x="7" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$29" x="9" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$30" x="9" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$31" x="11" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$32" x="11" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$33" x="13" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$34" x="13" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$35" x="15" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$36" x="15" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$37" x="17" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$38" x="17" y="-2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$39" x="19" y="2" dx="1" dy="2.5" layer="1"/>
+<smd name="P$40" x="19" y="-2" dx="1" dy="2.5" layer="1"/>
 <text x="-21.5" y="2" size="1.27" layer="21">1</text>
 <text x="-21.5" y="-3" size="1.27" layer="21">2</text>
 <text x="20.5" y="-3" size="1.27" layer="21">40</text>
 <text x="20.5" y="2" size="1.27" layer="21">39</text>
 <text x="24.13" y="-3.81" size="1.27" layer="25" rot="R90">&gt;NAME</text>
+<wire x1="-19.939" y1="2.032" x2="-19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="-19.939" y1="-2.032" x2="19.939" y2="-2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="-2.032" x2="19.939" y2="2.032" width="0.1524" layer="21"/>
+<wire x1="19.939" y1="2.032" x2="-19.939" y2="2.032" width="0.1524" layer="21"/>
 </package>
 <package name="61083-063402LF">
 <wire x1="-12" y1="3" x2="-15" y2="3" width="0.127" layer="21"/>
@@ -436,7 +397,7 @@ by exp-lbrs.ulp</description>
 </package>
 </packages>
 <symbols>
-<symbol name="40PIN-HEADER">
+<symbol name="40PIN-HEADER_MALE">
 <wire x1="-7.62" y1="27.94" x2="7.62" y2="27.94" width="0.254" layer="94"/>
 <wire x1="7.62" y1="27.94" x2="7.62" y2="-25.4" width="0.254" layer="94"/>
 <wire x1="7.62" y1="-25.4" x2="-7.62" y2="-25.4" width="0.254" layer="94"/>
@@ -566,21 +527,12 @@ by exp-lbrs.ulp</description>
 </symbol>
 </symbols>
 <devicesets>
-<deviceset name="55510-140LF" prefix="J">
-<description>&lt;h1&gt; 55510-140LF &lt;/h1&gt;
-   
-&lt;p&gt; &lt;b&gt;MANUFACTURER&lt;/b&gt; : Amphenol FCI &lt;/p&gt;
-
-&lt;p&gt; &lt;b&gt;DESCRIPTION&lt;/b&gt; Conn Socket Strip SKT 40 POS 2mm Solder ST SMD Tube &lt;/p&gt;
-
-&lt;p&gt; &lt;b&gt;Note&lt;/b&gt;: DragonBoard 410c LS Connector &lt;/p&gt;
-
-&lt;p&gt; Think of FCI's socket strip &lt;b&gt;55510-140LF&lt;/b&gt; header connector the next time you're concerned about accidentally shorting out pins on your printed circuit. This SKT connector's 40 contacts that are made out of phosphor bronze and plated with gold over nickel. It has a socket type gender. It has a straight body orientation. Its pitch is 2 mm. This is a 2-row connector. It has a maximum voltage rating of 200 VDC|200VAC. This device has a maximum current rating of 1 A/contact. In order to ensure parts aren't damaged by bulk packaging, this product comes in tube packaging to add a little more protection by storing the loose parts in an outer tube. This connector has an operating temperature of -55 to 125 °C. This product is 39.92 mm long, 4.5 mm tall and 4 mm deep. 55510-140LF is housed in black plastic. It uses the solder termination method.&lt;/p&gt;</description>
+<deviceset name="57202-G52-20LF">
 <gates>
-<gate name="G$1" symbol="40PIN-HEADER" x="0" y="17.78"/>
+<gate name="G$1" symbol="40PIN-HEADER_MALE" x="0" y="0"/>
 </gates>
 <devices>
-<device name="" package="55510-140LF">
+<device name="" package="57202-G52-20LF">
 <connects>
 <connect gate="G$1" pin="P$1" pad="P$1"/>
 <connect gate="G$1" pin="P$10" pad="P$10"/>
@@ -747,7 +699,7 @@ by exp-lbrs.ulp</description>
 </classes>
 <parts>
 <part name="PCB1" library="mezza" deviceset="DB410C-PCB-FOOTPRINT" device=""/>
-<part name="J1" library="mezza" deviceset="55510-140LF" device=""/>
+<part name="J1" library="mezza" deviceset="57202-G52-20LF" device=""/>
 <part name="J2" library="mezza" deviceset="61083-063402LF" device=""/>
 <part name="SUPPLY1" library="supply2" deviceset="GND" device=""/>
 <part name="SUPPLY2" library="supply2" deviceset="GND" device=""/>
@@ -774,19 +726,40 @@ Use the component reference center to align the connectors, then delete J1.</tex
 <attribute name="NAME" x="66.04" y="86.36" size="2.54" layer="95"/>
 <attribute name="VALUE" x="55.88" y="0" size="2.54" layer="96"/>
 </instance>
-<instance part="SUPPLY7" gate="GND" x="48.26" y="-5.08"/>
-<instance part="SUPPLY8" gate="GND" x="88.9" y="-5.08"/>
+<instance part="SUPPLY7" gate="GND" x="48.26" y="-5.08" smashed="yes">
+<attribute name="VALUE" x="46.355" y="-8.255" size="1.778" layer="96"/>
+</instance>
+<instance part="SUPPLY8" gate="GND" x="88.9" y="-5.08" smashed="yes">
+<attribute name="VALUE" x="86.995" y="-8.255" size="1.778" layer="96"/>
+</instance>
 <instance part="J1" gate="G$1" x="-66.04" y="48.26" smashed="yes">
 <attribute name="NAME" x="-68.58" y="78.74" size="2.54" layer="95"/>
 <attribute name="VALUE" x="-76.2" y="17.78" size="2.54" layer="96"/>
 </instance>
-<instance part="SUPPLY2" gate="GND" x="-83.82" y="81.28" rot="R180"/>
-<instance part="SUPPLY3" gate="GND" x="-83.82" y="12.7"/>
-<instance part="SUPPLY5" gate="GND" x="-48.26" y="81.28" rot="R180"/>
-<instance part="SUPPLY6" gate="GND" x="-48.26" y="12.7"/>
-<instance part="PCB1" gate="G$1" x="-63.5" y="-27.94"/>
-<instance part="SUPPLY1" gate="GND" x="-76.2" y="-48.26"/>
-<instance part="FRAME3" gate="G$1" x="-129.54" y="-68.58"/>
+<instance part="SUPPLY2" gate="GND" x="-83.82" y="81.28" smashed="yes" rot="R180">
+<attribute name="VALUE" x="-81.915" y="84.455" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY3" gate="GND" x="-83.82" y="12.7" smashed="yes">
+<attribute name="VALUE" x="-85.725" y="9.525" size="1.778" layer="96"/>
+</instance>
+<instance part="SUPPLY5" gate="GND" x="-48.26" y="81.28" smashed="yes" rot="R180">
+<attribute name="VALUE" x="-46.355" y="84.455" size="1.778" layer="96" rot="R180"/>
+</instance>
+<instance part="SUPPLY6" gate="GND" x="-48.26" y="12.7" smashed="yes">
+<attribute name="VALUE" x="-50.165" y="9.525" size="1.778" layer="96"/>
+</instance>
+<instance part="PCB1" gate="G$1" x="-63.5" y="-27.94" smashed="yes">
+<attribute name="VALUE" x="-78.74" y="-22.86" size="1.27" layer="96"/>
+<attribute name="NAME" x="-78.74" y="-25.4" size="1.27" layer="95"/>
+</instance>
+<instance part="SUPPLY1" gate="GND" x="-76.2" y="-48.26" smashed="yes">
+<attribute name="VALUE" x="-78.105" y="-51.435" size="1.778" layer="96"/>
+</instance>
+<instance part="FRAME3" gate="G$1" x="-129.54" y="-68.58" smashed="yes">
+<attribute name="DRAWING_NAME" x="87.63" y="-53.34" size="2.54" layer="94"/>
+<attribute name="LAST_DATE_TIME" x="87.63" y="-58.42" size="2.286" layer="94"/>
+<attribute name="SHEET" x="100.965" y="-63.5" size="2.54" layer="94"/>
+</instance>
 </instances>
 <busses>
 </busses>


### PR DESCRIPTION
Fixes https://github.com/96boards/mezzanine-community/issues/110 and https://github.com/96boards/mezzanine-community/issues/53

* Uses correct female header (55702-G52 / 4mm height)
* Fixes footprint layers to not use `dimension` 

I copied the male footprint and updated the pad dimensions from: https://cdn.amphenol-icc.com/media/wysiwyg/files/documentation/datasheet/boardwiretoboard/bwb_minitek_unshrouded_vh.pdf


